### PR TITLE
Update web_request_async_multi.cpp

### DIFF
--- a/chapter_20/web_request_async_multi.cpp
+++ b/chapter_20/web_request_async_multi.cpp
@@ -24,7 +24,10 @@ struct Request {
                       "Accept-Encoding: identity\r\n"
                       "Connection: close\r\n\r\n";
     request = request_stream.str();
-    resolver.async_resolve(this->host, "http", [this](boost::system::error_code ec, const ResolveResult& results) {
+  }
+
+  void resolve_request() {
+    resolver.async_resolve(host, "http", [this](boost::system::error_code ec, const ResolveResult& results) {
       resolution_handler(ec, results);
     });
   }
@@ -87,8 +90,12 @@ int main() {
 
   std::vector<Request> requests;
   std::generate_n(std::back_inserter(requests), n_requests, [&io_context] {
-    return Request{ io_context, "www.arcyber.army.mil" };
+    return Request{ io_context, "example.com" };
   });
+
+  for(size_t i = 0; i != n_requests; ++i) {
+    requests[i].resolve_request();
+  }
 
   std::vector<std::future<void>> futures;
   std::generate_n(std::back_inserter(futures), n_threads, [&io_context] {


### PR DESCRIPTION
Inside the constructor for the `Request` class, `resolver.async_resolve` captures `this` within a lambda. 
However, the `Request` object has not yet been created (function is called inside the constructor), so on exit this will be empty.  This is solved by moving `resolver.async_resolve` to its own function member, which allows the constructor to complete creating a `Request` object.

At this point it's possible to set `n_threads{2}` in main() and have the program run correctly. 
Try it on *example.com* as it still accepts simple http requests.